### PR TITLE
Fixing error when phigaro output was empty (#55)

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -2,7 +2,7 @@
     "description": "<p>The pipeline</p>\n\n<p>bacannot, is a customisable, easy to use, pipeline that uses state-of-the-art software for comprehensively annotating prokaryotic genomes having only Docker and Nextflow as dependencies. It is able to annotate and detect virulence and resistance genes, plasmids, secondary metabolites, genomic islands, prophages, ICEs, KO, and more, while providing nice an beautiful interactive documents for results exploration.</p>", 
     "license": "other-open", 
     "title": "fmalmeida/bacannot: A generic but comprehensive bacterial annotation pipeline", 
-    "version": "v3.1.1", 
+    "version": "v3.1.2", 
     "upload_type": "software",
     "creators": [
         {

--- a/docker/renv/build.sh
+++ b/docker/renv/build.sh
@@ -1,1 +1,2 @@
-../../bin/build_image.sh $1
+source ../set_version.sh
+../../bin/build_image.sh $NEW_VERSION

--- a/docker/renv/reports/report_custom_blast.Rmd
+++ b/docker/renv/reports/report_custom_blast.Rmd
@@ -59,12 +59,10 @@ check_lines <- function(x) {
 
 ## Read input documents
 custom_blast <- try(read.delim(params$custom_blast, header = TRUE), silent = TRUE)
-blast_gff    <- try(read.delim(params$blast_gff, header = FALSE), silent = TRUE)
-colnames(blast_gff) <-
-  c("Contig", "Source", "Feature", "Start", "End", "Score", "Strand", "Phase", "Attributes")
+blast_gff    <- try(read.delim(params$blast_gff, header = FALSE, col.names=c("Contig", "Source", "Feature", "Start", "End", "Score", "Strand", "Phase", "Attributes")), silent = TRUE)
 
 ## Check for emptyness
-if (class(custom_blast) == "try-error" ||
+if (class(blast_gff) == "try-error" ||
     check_lines(custom_blast) == 1) {
   custom_blast <- data.frame(
     matrix(ncol = 14, nrow = 0)
@@ -72,6 +70,8 @@ if (class(custom_blast) == "try-error" ||
   blast_gff <- data.frame(
     matrix(ncol = 9, nrow = 0)
   )
+  colnames(blast_gff) <-
+  c("Contig", "Source", "Feature", "Start", "End", "Score", "Strand", "Phase", "Attributes")
 } else {
   
   # read blast summary
@@ -91,6 +91,9 @@ if (class(custom_blast) == "try-error" ||
   blast_gff$`Query Protein ID` <- getAttributeField(blast_gff$Attributes, "ID", ";")
   blast_gff$`Prokka Annotation (Gene)` <- getAttributeField(blast_gff$Attributes, "gene", ";")
   blast_gff$`Prokka Annotation (Product)` <- getAttributeField(blast_gff$Attributes, "product", ";")
+  
+  blast_gff <- blast_gff %>%
+    select(`Query Protein ID`, `Prokka Annotation (Gene)`, `Prokka Annotation (Product)`, `Custom DB Acc`, `Custom DB Target`, `Custom DB Product`, Attributes)
 }
 ```
 
@@ -144,10 +147,7 @@ Using the software bedtools intersect, the BLAST results have been used to searc
 <br>
 <caption>(#tab:blast-gff-table) Annotation intersection of the `r params$blast_db` custom database BLAST results with the main pipeline results</caption>
 ```{r}
-blast <- blast_gff
-# Render dt
-datatable(blast %>%
-            select(`Query Protein ID`, `Prokka Annotation (Gene)`, `Prokka Annotation (Product)`, `Custom DB Acc`, `Custom DB Target`, `Custom DB Product`, Attributes),
+datatable(blast_gff,
           escape = FALSE,
           filter = 'top',
           options = list(pageLength = 5,

--- a/lib/WorkflowMain.groovy
+++ b/lib/WorkflowMain.groovy
@@ -66,7 +66,7 @@ class WorkflowMain {
 
         // Download template samplesheet
         if (params.get_samplesheet) {
-            new File("bacannot_samplesheet.yaml").write(new URL ("https://github.com/fmalmeida/bacannot/raw/master/example_samplesheet.yml").getText())
+            new File("bacannot_samplesheet.yaml").write(new URL ("https://github.com/fmalmeida/bacannot/raw/master/example_samplesheet.yaml").getText())
             log.info """
             Samplesheet (bacannot_samplesheet.yml) file saved in working directory
             Nice code!

--- a/main.nf
+++ b/main.nf
@@ -52,11 +52,11 @@ workflow {
       Cheers.
       """)
     } else {
-      bacannot_db = file(params.bacannot_db)
+      bacannot_db = file(params.bacannot_db, checkIfExists: true)
     }
 
     // Load yaml
-    samplesheet_yaml = file(params.input)
+    samplesheet_yaml = file(params.input, checkIfExists: true)
     parameter_yaml = samplesheet_yaml.readLines().join("\n")
     new Yaml().load(parameter_yaml).each { k, v -> params[k] = v }
 

--- a/markdown/CHANGELOG.md
+++ b/markdown/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 The tracking for changes started in v2.1
 
+## v3.1.2
+
+This version contains:
+
+* A fix on the custom blast report file which had an wrong ifelse statement definition
+* Updated version of renv docker with fixed report Rmd
+* Addition of `checkIfExists` statements when loading file to make sure that user is pointing to files that exists and did not misspelled them
+* Fixed a small misspelling on example samplesheet url
+* A small fix on phigaro.nf module which was causing the pipeline to fail when its outputs were empty
+
+Thanks to @fetyj for spotting these issues.
+
 ## v3.1.1
 
 This version contains a quick fix spotted by @fetyj described in issue [#52](https://github.com/fmalmeida/bacannot/issues/52). Now the path to the argminer backup database is given as full path.

--- a/modules/generic/custom_database_report.nf
+++ b/modules/generic/custom_database_report.nf
@@ -23,7 +23,7 @@ process CUSTOM_DATABASE_REPORT {
   system("rm -f input.??") ;
   system("rm -f input.?") ;
 
-  ## Generate Resistance Report
+  ## Generate Report
   rmarkdown::render("report_custom_blast.Rmd", params = list(\
     blast_id = ${params.blast_custom_minid} , \
     blast_cov = ${params.blast_custom_mincov}, \

--- a/modules/prophages/phigaro.nf
+++ b/modules/prophages/phigaro.nf
@@ -1,7 +1,6 @@
 process PHIGARO {
   publishDir "${params.output}/${prefix}", mode: 'copy', saveAs: { filename ->
-    if (filename == "out.phg") null
-    else if (filename.indexOf("_version.txt") > 0) "tools_versioning/$filename"
+    if (filename.indexOf("_version.txt") > 0) "tools_versioning/$filename"
     else "prophages/phigaro/$filename"
   }
   tag "${prefix}"
@@ -46,11 +45,12 @@ process PHIGARO {
       --not-open ;
 
   # change names
-  [ ! -s out.phg/assembly.phigaro.tsv  ] || mv out.phg/assembly.phigaro.tsv ${prefix}_phigaro.tsv ;
-  [ ! -s out.phg/assembly.phigaro.html ] || mv out.phg/assembly.phigaro.html ${prefix}_phigaro.html ;
+  [ ! -s out.phg/assembly.phigaro.tsv  ] || cp out.phg/assembly.phigaro.tsv ${prefix}_phigaro.tsv ;
+  [ ! -s out.phg/assembly.phigaro.html ] || cp out.phg/assembly.phigaro.html ${prefix}_phigaro.html ;
 
   # create BED
-  grep -v "taxonomy" ${prefix}_phigaro.tsv | \
-  awk 'BEGIN { FS = "\t"; OFS="\\t" } { print \$1,\$2,\$3 }' > ${prefix}_phigaro.bed
+  touch ${prefix}_phigaro.bed ;
+  [ ! -s out.phg/assembly.phigaro.html ] || grep -v "taxonomy" ${prefix}_phigaro.tsv | \\
+      awk 'BEGIN { FS = "\\t"; OFS="\\t" } { print \$1,\$2,\$3 }' > ${prefix}_phigaro.bed
   """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -104,7 +104,7 @@ manifest {
     homePage        = "https://github.com/fmalmeida/bacannot"
     mainScript      = "main.nf"
     nextflowVersion = ">=20.10.0"
-    version         = '3.1.1'
+    version         = '3.1.2'
 }
 
 // Function to ensure that resource requirements don't go beyond

--- a/workflows/parse_samples.nf
+++ b/workflows/parse_samples.nf
@@ -13,13 +13,13 @@ workflow PARSE_SAMPLESHEET {
       tuple(
         row.name, 
         row.entrypoint,
-        (row.fwd == "missing_pairFWD") ? row.fwd : file(row.fwd), 
-        (row.rev == "missing_pairREV") ? row.rev : file(row.rev),
-        (row.single == "missing_single") ? row.single : file(row.single), 
-        (row.lreads == "missing_lreads") ? row.lreads : file(row.lreads), 
+        (row.fwd == "missing_pairFWD") ? row.fwd : file(row.fwd, checkIfExists: true), 
+        (row.rev == "missing_pairREV") ? row.rev : file(row.rev, checkIfExists: true),
+        (row.single == "missing_single") ? row.single : file(row.single, checkIfExists: true), 
+        (row.lreads == "missing_lreads") ? row.lreads : file(row.lreads, checkIfExists: true), 
         row.lr_type,
-        (row.fast5 == "missing_fast5") ? row.fast5 : file(row.fast5), 
-        (row.assembly == "missing_assembly") ? row.assembly : file(row.assembly), 
+        (row.fast5 == "missing_fast5") ? row.fast5 : file(row.fast5, checkIfExists: true), 
+        (row.assembly == "missing_assembly") ? row.assembly : file(row.assembly, checkIfExists: true), 
         row.resfinder
       )
     }


### PR DESCRIPTION
This version contains:

* A fix on the custom blast report file which had an wrong ifelse statement definition
* Updated version of renv docker with fixed report Rmd
* Addition of `checkIfExists` statements when loading file to make sure that user is pointing to files that exists and did not misspelled them
* * Fixed a small misspelling in example samplesheet url
* A small fix on phigaro.nf module which was causing the pipeline to fail when its outputs were empty

Thanks to @fetyj for spotting these issues.