### PR TITLE
62 islandpath failed when there is no cds in bakta annotated gbk file

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -2,7 +2,7 @@
     "description": "<p>The pipeline</p>\n\n<p>bacannot, is a customisable, easy to use, pipeline that uses state-of-the-art software for comprehensively annotating prokaryotic genomes having only Docker and Nextflow as dependencies. It is able to annotate and detect virulence and resistance genes, plasmids, secondary metabolites, genomic islands, prophages, ICEs, KO, and more, while providing nice an beautiful interactive documents for results exploration.</p>", 
     "license": "other-open", 
     "title": "fmalmeida/bacannot: A generic but comprehensive bacterial annotation pipeline", 
-    "version": "v3.1.3", 
+    "version": "v3.1.4", 
     "upload_type": "software",
     "creators": [
         {

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Its main steps are:
 | :------------- | :------------------------- |
 | Genome assembly (if raw reads are given) | [Flye](https://github.com/fenderglass/Flye) and [Unicycler](https://github.com/rrwick/Unicycler) |
 | Identification of closest 10 NCBI Refseq genomes | [RefSeq Masher](https://github.com/phac-nml/refseq_masher) |
-| Generic annotation and gene prediction | [Prokka](https://github.com/tseemann/prokka) |
+| Generic annotation and gene prediction | [Prokka](https://github.com/tseemann/prokka) or [Bakta](https://github.com/oschwengers/bakta) |
 | rRNA prediction | [barrnap](https://github.com/tseemann/barrnap) |
 | Classification within multi-locus sequence types (STs) | [mlst](https://github.com/tseemann/mlst) |
 | KEGG KO annotation and visualization | [KofamScan](https://github.com/takaram/kofam_scan) and [KEGGDecoder](https://github.com/bjtully/BioData/tree/master/KEGGDecoder) |

--- a/markdown/CHANGELOG.md
+++ b/markdown/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The tracking for changes started in v2.1
 
+## v3.1.3 [13-September-2022]
+
+* Fixes https://github.com/fmalmeida/bacannot/issues/62 reported by @rujinlong, where Island-Path tool was failling because it was running on genbank files with no true CDS. This was hapenning because Bakta writes in the comments that the GBK has 0 CDS and, at first, the module was selecting GBK by checking if the CDS string was there. It has now been modified to also work with Bakta.
+
 ## v3.1.3 [9-September-2022]
 
 Main changes:

--- a/modules/MGEs/islandpath.nf
+++ b/modules/MGEs/islandpath.nf
@@ -19,7 +19,7 @@ process ISLANDPATH {
   touch ${prefix}_predicted_GIs.bed ;
   for file in \$(ls *.gbk); do \
     touch \${file%%.gbk}_GIs.txt ;
-    grep -q "CDS" \$file && \\
+    ( sed '/CDS.*::.*0/d' \$file | grep -q "CDS" ) && \\
         islandpath \\
         \$file \\
         \${file%%.gbk}_GIs.txt 2> dimob.err ;


### PR DESCRIPTION
FIxes #62.

Adding a simple `sed` command do delete Bakta comment lines where no CDS was annotated.