### PR TITLE
Minor improvements for custom database annotation

### DIFF
--- a/bin/run_blasts.py
+++ b/bin/run_blasts.py
@@ -146,8 +146,16 @@ def summary(output):
         db=line["sseqid"].split('~~~')[0]
         gene=line["sseqid"].split('~~~')[1]
         acc=line["sseqid"].split('~~~')[2]
-        prodc=line["sseqid"].split('~~~')[3].split(' ')[0]
-        desc=' '.join(line["stitle"].split('~~~')[3].split(' ')[1:-1])
+
+        if len(line["sseqid"].split('~~~')) == 5:
+            prodc=line["sseqid"].split('~~~')[3]
+            desc=line["sseqid"].split('~~~')[4]
+        else:
+            prodc=line["sseqid"].split('~~~')[3].split(' ')[0]
+            try:
+                desc=' '.join(line["stitle"].split('~~~')[3].split(' ')[1:-1])
+            except:
+                desc='Not found'
         # Subject coverage
         cov=round((100 * (line["length"] - line["gaps"]) / line["slen"]), 2)
         # Identity

--- a/bin/run_blasts.py
+++ b/bin/run_blasts.py
@@ -146,8 +146,8 @@ def summary(output):
         db=line["sseqid"].split('~~~')[0]
         gene=line["sseqid"].split('~~~')[1]
         acc=line["sseqid"].split('~~~')[2]
-        prodc=line["sseqid"].split('~~~')[3]
-        desc=line["sseqid"].split('~~~')[4]
+        prodc=line["sseqid"].split('~~~')[3].split(' ')[0]
+        desc=' '.join(line["stitle"].split('~~~')[3].split(' ')[1:-1])
         # Subject coverage
         cov=round((100 * (line["length"] - line["gaps"]) / line["slen"]), 2)
         # Identity

--- a/conf/test_profile.config
+++ b/conf/test_profile.config
@@ -62,5 +62,7 @@ params {
            */
 // Custom nucleotide fastas
   custom_db = 'https://github.com/fmalmeida/test_datasets/raw/main/small_custom_db.fasta'
+// Custom annotation based on NCBI protein IDs
+  ncbi_proteins = 'https://github.com/fmalmeida/test_datasets/raw/main/haemophilus_ncbi_proteins.txt'
 
 }

--- a/docker/server/scripts/shiny_parser.Rmd
+++ b/docker/server/scripts/shiny_parser.Rmd
@@ -144,7 +144,7 @@ if (length(files_list) > 0) {
   cat("* Reports of custom database annotations:\n")
   for (report_file in string.list) {
    cat(paste("\t* [Report: ", trimws(basename(report_file), which = 'both'),
-             "](", trimws(report_file, which = 'both'), ")"), sep = '\n')
+             "](", trimws(report_file, which = 'both'), ")", sep = ''), sep = '\n')
   }
 }
 

--- a/modules/generic/custom_database.nf
+++ b/modules/generic/custom_database.nf
@@ -24,6 +24,16 @@ process CUSTOM_DATABASE {
   fi
 
   # Step 2 - Execute blast
+  if [[ \${blast_cmd} == "blastn" ]]
+  then
+      ## In case the blast dabase throw error below:
+      ## BLAST Database error: No alias or index file found for nucleotide database
+      makeblastdb \\
+          -dbtype nucl \\
+          -in ${customDB} \\
+          -out ${customDB} ;
+  fi
+
   run_blasts.py \\
       \${blast_cmd} \\
       --query ${genome} \\
@@ -31,11 +41,11 @@ process CUSTOM_DATABASE {
       --minid ${params.blast_custom_minid} \\
       --mincov ${params.blast_custom_mincov} \\
       --threads $task.cpus \\
-      --out ${prefix}_${customDB.baseName}_\${blast_cmd}.txt \\
-      > ${prefix}_${customDB.baseName}_\${blast_cmd}.summary.txt ;
+      --out ${prefix}_${customDB.baseName}_\${blast_cmd}_onGenome.txt \\
+      > ${prefix}_${customDB.baseName}_\${blast_cmd}_onGenome.summary.txt ;
 
   # Step 3 - Produce custom gff
-  tail -n+2 ${prefix}_${customDB.baseName}_\${blast_cmd}.summary.txt | \\
+  tail -n+2 ${prefix}_${customDB.baseName}_\${blast_cmd}_onGenome.summary.txt | \\
   awk \\
     -v source="${customDB.baseName}" \\
     -F'\\t' \\

--- a/modules/generic/custom_database.nf
+++ b/modules/generic/custom_database.nf
@@ -34,6 +34,16 @@ process CUSTOM_DATABASE {
           -out ${customDB} ;
   fi
 
+  if [[ \${blast_cmd} == "tblastn" ]]
+  then
+      ## In case the blast dabase throw error below:
+      ## BLAST Database error: No alias or index file found for nucleotide database
+      makeblastdb \\
+          -dbtype prot \\
+          -in ${customDB} \\
+          -out ${customDB} ;
+  fi
+
   run_blasts.py \\
       \${blast_cmd} \\
       --query ${genome} \\

--- a/workflows/bacannot.nf
+++ b/workflows/bacannot.nf
@@ -297,7 +297,7 @@ workflow BACANNOT {
       // Render reports
       if (params.custom_db || params.ncbi_proteins) {
         CUSTOM_DATABASE_REPORT( 
-          CUSTOM_DATABASE.out.summary.join( MERGE_ANNOTATIONS.out.gff, remainder:true ) 
+          CUSTOM_DATABASE.out.summary.join( MERGE_ANNOTATIONS.out.customdb_gff, remainder:true ) 
         )
       }
       REPORT(


### PR DESCRIPTION
Some bugs happened when using custom databases for annotation, so I simply modified codes to solve them. Changes are roughly about:

- Make Blast DB when executing `blastn` for annotating custom database, to resolve errors lacking index file for nucleotide db;
- Strip spaces in Shiny markdown for properly generating links to custom database reports.

There still exist bugs in custom database reports. Some of the report html file are empty when assigning multiple custom databases, while the annotation files (`.summary.txt`, `.gff`, both not empty) successfully completed. I'm not sure if this problem are caused by modification above.

Thank you soooo much for your patience, and this awesome tool!