### PR TITLE
FIX: antismash results can be empty

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -2,7 +2,7 @@
     "description": "<p>The pipeline</p>\n\n<p>bacannot, is a customisable, easy to use, pipeline that uses state-of-the-art software for comprehensively annotating prokaryotic genomes having only Docker and Nextflow as dependencies. It is able to annotate and detect virulence and resistance genes, plasmids, secondary metabolites, genomic islands, prophages, ICEs, KO, and more, while providing nice an beautiful interactive documents for results exploration.</p>", 
     "license": "other-open", 
     "title": "fmalmeida/bacannot: A generic but comprehensive bacterial annotation pipeline", 
-    "version": "v3.1.5", 
+    "version": "v3.1.6", 
     "upload_type": "software",
     "creators": [
         {

--- a/markdown/CHANGELOG.md
+++ b/markdown/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The tracking for changes started in v2.1
 
+## v3.1.6 [7-November-2022]
+
+* Fixes https://github.com/fmalmeida/bacannot/issues/71 reported by @fetyj, which highlights that antismash module was failing when outputs for a sample were empty.
+  - To solve this issue, the module was updated as such the antismash main results is now optional instead of being required, and 'gff conversion' steps are done only when it's results are not empty.
+  - PR: https://github.com/fmalmeida/bacannot/pull/72
+
 ## v3.1.5 [17-September-2022]
 
 * Fixes https://github.com/fmalmeida/bacannot/issues/64 reported by @fmalmeida, which highlights that the resfinder annotation were sometimes being duplicated because a single gene had intersection to more then one CDS regions, but, only one being "true".

--- a/modules/generic/antismash.nf
+++ b/modules/generic/antismash.nf
@@ -11,7 +11,7 @@ process ANTISMASH {
   file(bacannot_db)
 
   output:
-  tuple val(prefix), path("antiSMASH/regions.gff"), emit: gff
+  tuple val(prefix), path("antiSMASH/regions.gff"), emit: gff, optional: true
   path("antiSMASH")                               , emit: all
   path("*_version.txt")                           , emit: version
 
@@ -47,19 +47,24 @@ process ANTISMASH {
     -auto ;
 
   # get the locus tags annotated as list
-  grep \\
-    "locus_tag" \\
-    *region*gbk | \\
-    cut \\
-    -f 2 \\
-    -d "=" | \\
-    tr -d '"' | \\
-    sort -u > gene_ids.lst ;
+  # only when results exist
+  if ls *region*gbk 1> /dev/null 2>&1; then
 
-  # subset regions GFF from main GFF for JBrowse
-  grep \\
-    -w \\
-    -f gene_ids.lst \\
-    ${gbk_prefix}.gff > regions.gff ;
+    grep \\
+      "locus_tag" \\
+      *region*gbk | \\
+      cut \\
+      -f 2 \\
+      -d "=" | \\
+      tr -d '"' | \\
+      sort -u > gene_ids.lst ;
+
+    # subset regions GFF from main GFF for JBrowse
+    grep \\
+      -w \\
+      -f gene_ids.lst \\
+      ${gbk_prefix}.gff > regions.gff ;
+  
+  fi
   """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -104,7 +104,7 @@ manifest {
     homePage        = "https://github.com/fmalmeida/bacannot"
     mainScript      = "main.nf"
     nextflowVersion = ">=20.10.0"
-    version         = '3.1.5'
+    version         = '3.1.6'
 }
 
 // Function to ensure that resource requirements don't go beyond


### PR DESCRIPTION
Adding a simple fix to `ANTISMASH` module to allow that outputs from the tool can be empty.