### PR TITLE
75 upgrade bakta to 151+

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -2,7 +2,7 @@
     "description": "<p>The pipeline</p>\n\n<p>bacannot, is a customisable, easy to use, pipeline that uses state-of-the-art software for comprehensively annotating prokaryotic genomes having only Docker and Nextflow as dependencies. It is able to annotate and detect virulence and resistance genes, plasmids, secondary metabolites, genomic islands, prophages, ICEs, KO, and more, while providing nice an beautiful interactive documents for results exploration.</p>", 
     "license": "other-open", 
     "title": "fmalmeida/bacannot: A generic but comprehensive bacterial annotation pipeline", 
-    "version": "v3.1.6", 
+    "version": "v3.1.7", 
     "upload_type": "software",
     "creators": [
         {

--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -171,9 +171,9 @@ params {
 // Select versions of bioconda quay.io additional tools
 // Tools that are not part of the core of the pipeline,
 // but can eventually be used by users
-unicycler_version = '0.4.8--py38h8162308_3'
-flye_version      = '2.9--py39h39abbe0_0'
-bakta_version     = '1.6.0--pyhdfd78af_0'
+  unicycler_version = '0.4.8--py38h8162308_3'
+  flye_version      = '2.9--py39h39abbe0_0'
+  bakta_version     = '1.6.0--pyhdfd78af_0'
 
 // Max resource options
 // Defaults only, expecting to be overwritten

--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -168,6 +168,13 @@ params {
 // User's custom database coverage threshold
   blast_custom_mincov = 65
 
+// Select versions of bioconda quay.io additional tools
+// Tools that are not part of the core of the pipeline,
+// but can eventually be used by users
+unicycler_version = '0.4.8--py38h8162308_3'
+flye_version      = '2.9--py39h39abbe0_0'
+bakta_version     = '1.6.0--pyhdfd78af_0'
+
 // Max resource options
 // Defaults only, expecting to be overwritten
   max_memory                 = '20.GB'

--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -173,7 +173,7 @@ params {
 // but can eventually be used by users
   unicycler_version = '0.4.8--py38h8162308_3'
   flye_version      = '2.9--py39h39abbe0_0'
-  bakta_version     = '1.6.0--pyhdfd78af_0'
+  bakta_version     = '1.6.1--pyhdfd78af_0'
 
 // Max resource options
 // Defaults only, expecting to be overwritten

--- a/conf/docker.config
+++ b/conf/docker.config
@@ -44,15 +44,15 @@ process {
     }
 
     withName: UNICYCLER {
-        container = 'quay.io/biocontainers/unicycler:0.4.8--py38h8162308_3'
+        container = "quay.io/biocontainers/unicycler:${params.unicycler_version}"
     }
 
     withName: FLYE {
-        container = 'quay.io/biocontainers/flye:2.9--py39h39abbe0_0'
+        container = "quay.io/biocontainers/flye:${params.flye_version}"
     }
 
     withName: BAKTA {
-        container = 'quay.io/biocontainers/bakta:1.6.0--pyhdfd78af_0'
+        container = "quay.io/biocontainers/bakta:${params.bakta_version}"
     }
 
     /*

--- a/conf/docker.config
+++ b/conf/docker.config
@@ -52,7 +52,7 @@ process {
     }
 
     withName: BAKTA {
-        container = 'quay.io/biocontainers/bakta:1.5.0--pyhdfd78af_0'
+        container = 'quay.io/biocontainers/bakta:1.6.0--pyhdfd78af_0'
     }
 
     /*

--- a/conf/singularity.config
+++ b/conf/singularity.config
@@ -42,15 +42,15 @@ process {
     }
 
     withName: UNICYCLER {
-        container = 'https://depot.galaxyproject.org/singularity/unicycler:0.4.8--py38h8162308_3'
+        container = "https://depot.galaxyproject.org/singularity/unicycler:${params.unicycler_version}"
     }
 
     withName: FLYE {
-        container = 'https://depot.galaxyproject.org/singularity/flye:2.9--py39h39abbe0_0'
+        container = "https://depot.galaxyproject.org/singularity/flye:${params.flye_version}"
     }
 
     withName: BAKTA {
-        container = 'https://depot.galaxyproject.org/singularity/bakta:1.6.0--pyhdfd78af_0'
+        container = "https://depot.galaxyproject.org/singularity/bakta:${params.bakta_version}"
     }
 
     /*

--- a/conf/singularity.config
+++ b/conf/singularity.config
@@ -49,6 +49,10 @@ process {
         container = 'https://depot.galaxyproject.org/singularity/flye:2.9--py39h39abbe0_0'
     }
 
+    withName: BAKTA {
+        container = 'https://depot.galaxyproject.org/singularity/bakta:1.6.0--pyhdfd78af_0'
+    }
+
     /*
      * Other (non-image) customization
      */

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -125,6 +125,16 @@ Users can give fasta files (nucl or prot) properly formatted or a text file cont
 | :--------------------------------------- | :------- | :------ | :---------- |
 | `--bedtools_merge_distance` | :material-close: | NA | Minimum number of required overlapping bases to merge genes. By default it is not executed. |
 
+## Non-core tools versions
+
+Users can now select the version of the non-core tools Bakta, Unicyler and Flye. These tools now have a parameter which controls which tag, thus version, from quay.io to use.
+
+| Parameter | Default | Description |
+| :-------- | :------ | :---------- |
+| `--bakta_version`     | 1.6.0--pyhdfd78af_0   | Bakta tool version     |
+| `--flye_version`      | 2.9--py39h39abbe0_0   | Flye tool version      |
+| `--unicycler_version` | 0.4.8--py38h8162308_3 | Unicycler tool version |
+
 ## Max job request options
 
 Set the top limit for requested resources for any single job. If you are running on a smaller system, a pipeline step requesting more resources than are available may cause the Nextflow to stop the run with an error. These options allow you to cap the maximum resources requested by any single job so that the pipeline will run on your system.

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -131,7 +131,7 @@ Users can now select the version of the non-core tools Bakta, Unicyler and Flye.
 
 | Parameter | Default | Description |
 | :-------- | :------ | :---------- |
-| `--bakta_version`     | 1.6.0--pyhdfd78af_0   | Bakta tool version     |
+| `--bakta_version`     | 1.6.1--pyhdfd78af_0   | Bakta tool version     |
 | `--flye_version`      | 2.9--py39h39abbe0_0   | Flye tool version      |
 | `--unicycler_version` | 0.4.8--py38h8162308_3 | Unicycler tool version |
 

--- a/markdown/CHANGELOG.md
+++ b/markdown/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 The tracking for changes started in v2.1
 
-## v3.1.7 [?-December-2022]
+## v3.1.7 [6-December-2022]
 
 * Fixes https://github.com/fmalmeida/bacannot/issues/75 reported by @sunitj, who highlighted that bakta tool required an update.
-* Now, as a consequence, the non-core tools, namelt Bakta, Flye and Unicycler that are used only when required in particular cases now have a parameter to control the version of the tool desired.
+* Now, as a consequence, the non-core tools, namely Bakta, Flye and Unicycler that are used only when required in particular cases now have a parameter to control the version of the tool desired.
   * These non-default tools are used with bioconda images from quay.io, now they have parameters `--bakta_version`, `--unicycler_version` and `--flye_version` that allows users to control the version (from quay.io) used.
 * PR: https://github.com/fmalmeida/bacannot/pull/76
 

--- a/markdown/CHANGELOG.md
+++ b/markdown/CHANGELOG.md
@@ -2,9 +2,16 @@
 
 The tracking for changes started in v2.1
 
+## v3.1.7 [?-December-2022]
+
+* Fixes https://github.com/fmalmeida/bacannot/issues/75 reported by @sunitj, who highlighted that bakta tool required an update.
+* Now, as a consequence, the non-core tools, namelt Bakta, Flye and Unicycler that are used only when required in particular cases now have a parameter to control the version of the tool desired.
+  * These non-default tools are used with bioconda images from quay.io, now they have parameters `--bakta_version`, `--unicycler_version` and `--flye_version` that allows users to control the version (from quay.io) used.
+* PR: https://github.com/fmalmeida/bacannot/pull/76
+
 ## v3.1.6 [7-November-2022]
 
-* Fixes https://github.com/fmalmeida/bacannot/issues/71 reported by @fetyj, which highlights that antismash module was failing when outputs for a sample were empty.
+* Fixes https://github.com/fmalmeida/bacannot/issues/71 reported by @fetyj, who highlights that antismash module was failing when outputs for a sample were empty.
   - To solve this issue, the module was updated as such the antismash main results is now optional instead of being required, and 'gff conversion' steps are done only when it's results are not empty.
   - PR: https://github.com/fmalmeida/bacannot/pull/72
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -104,7 +104,7 @@ manifest {
     homePage        = "https://github.com/fmalmeida/bacannot"
     mainScript      = "main.nf"
     nextflowVersion = ">=20.10.0"
-    version         = '3.1.6'
+    version         = '3.1.7'
 }
 
 // Function to ensure that resource requirements don't go beyond

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -343,7 +343,7 @@
                 "bakta_version": {
                     "type": "string",
                     "description": "Select quay.io image tag for tool",
-                    "default": "1.6.0--pyhdfd78af_0"
+                    "default": "1.6.1--pyhdfd78af_0"
                 }
             }
         },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -174,7 +174,7 @@
                 "plasmids_minid": {
                     "type": "number",
                     "description": "Identity threshold for plasmid annotation",
-                    "default": 90,
+                    "default": 90.0,
                     "minimum": 0,
                     "maximum": 100,
                     "help_text": "Must be between 0 and 100",
@@ -183,7 +183,7 @@
                 "plasmids_mincov": {
                     "type": "number",
                     "description": "overage threshold for plasmid annotation",
-                    "default": 60,
+                    "default": 60.0,
                     "minimum": 0,
                     "maximum": 100,
                     "help_text": "Must be between 0 and 100",
@@ -192,7 +192,7 @@
                 "blast_virulence_minid": {
                     "type": "number",
                     "description": "Identity threshold for virulence factors annotation",
-                    "default": 90,
+                    "default": 90.0,
                     "minimum": 0,
                     "maximum": 100,
                     "help_text": "Must be between 0 and 100",
@@ -201,7 +201,7 @@
                 "blast_virulence_mincov": {
                     "type": "number",
                     "description": "overage threshold for virulence factors annotation",
-                    "default": 90,
+                    "default": 90.0,
                     "minimum": 0,
                     "maximum": 100,
                     "help_text": "Must be between 0 and 100",
@@ -210,7 +210,7 @@
                 "blast_resistance_minid": {
                     "type": "number",
                     "description": "Identity threshold for resistance genes annotation",
-                    "default": 90,
+                    "default": 90.0,
                     "minimum": 0,
                     "maximum": 100,
                     "help_text": "Must be between 0 and 100",
@@ -219,7 +219,7 @@
                 "blast_resistance_mincov": {
                     "type": "number",
                     "description": "overage threshold for resistance genes annotation",
-                    "default": 90,
+                    "default": 90.0,
                     "minimum": 0,
                     "maximum": 100,
                     "help_text": "Must be between 0 and 100",
@@ -228,7 +228,7 @@
                 "blast_MGEs_minid": {
                     "type": "number",
                     "description": "Identity threshold for ICEs and prophages annotation",
-                    "default": 85,
+                    "default": 85.0,
                     "minimum": 0,
                     "maximum": 100,
                     "help_text": "Must be between 0 and 100",
@@ -237,7 +237,7 @@
                 "blast_MGEs_mincov": {
                     "type": "number",
                     "description": "overage threshold for ICEs and prophages annotation",
-                    "default": 85,
+                    "default": 85.0,
                     "minimum": 0,
                     "maximum": 100,
                     "help_text": "Must be between 0 and 100",
@@ -267,7 +267,7 @@
                 "blast_custom_minid": {
                     "type": "number",
                     "description": "Min. identity % for the annotation using user's custom database",
-                    "default": 65,
+                    "default": 65.0,
                     "minimum": 0,
                     "maximum": 100,
                     "hidden": true
@@ -275,7 +275,7 @@
                 "blast_custom_mincov": {
                     "type": "number",
                     "description": "Min. gene/subject coverage % for the annotation using user's custom database",
-                    "default": 65,
+                    "default": 65.0,
                     "minimum": 0,
                     "maximum": 100,
                     "hidden": true
@@ -329,6 +329,21 @@
                     "description": "Show all params when using `--help`",
                     "hidden": true,
                     "help_text": "By default, parameters set as _hidden_ in the schema are not shown on the command line when a user runs with `--help`. Specifying this option will tell the pipeline to show all parameters."
+                },
+                "unicycler_version": {
+                    "type": "string",
+                    "description": "Select quay.io image tag for tool",
+                    "default": "0.4.8--py38h8162308_3"
+                },
+                "flye_version": {
+                    "type": "string",
+                    "description": "Select quay.io image tag for tool",
+                    "default": "2.9--py39h39abbe0_0"
+                },
+                "bakta_version": {
+                    "type": "string",
+                    "description": "Select quay.io image tag for tool",
+                    "default": "1.6.0--pyhdfd78af_0"
                 }
             }
         },


### PR DESCRIPTION
Bakta is now updated to version 1.6.0 and non-core tools that use images from quay.io have a parameter to allow users to select version of tool used.