### PR TITLE
85 prokka module can get after modules stuck if the header file longer than 20 and not separated by tab or space

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -177,7 +177,7 @@ params {
 // but can eventually be used by users
   unicycler_version = '0.4.8--py38h8162308_3'
   flye_version      = '2.9--py39h39abbe0_0'
-  bakta_version     = '1.6.1--pyhdfd78af_0'
+  bakta_version     = '1.7.0--pyhdfd78af_1'
 
 // Max resource options
   max_memory                 = '20.GB'

--- a/docs/config.md
+++ b/docs/config.md
@@ -192,7 +192,7 @@ params {
 // but can eventually be used by users
   unicycler_version = '0.4.8--py38h8162308_3'
   flye_version      = '2.9--py39h39abbe0_0'
-  bakta_version     = '1.6.1--pyhdfd78af_0'
+  bakta_version     = '1.7.0--pyhdfd78af_1'
 
 // Max resource options
   max_memory                 = '20.GB'

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -131,7 +131,7 @@ Users can now select the version of the non-core tools Bakta, Unicyler and Flye.
 
 | Parameter | Default | Description |
 | :-------- | :------ | :---------- |
-| `--bakta_version`     | 1.6.1--pyhdfd78af_0   | Bakta tool version     |
+| `--bakta_version`     | 1.7.0--pyhdfd78af_1   | Bakta tool version     |
 | `--flye_version`      | 2.9--py39h39abbe0_0   | Flye tool version      |
 | `--unicycler_version` | 0.4.8--py38h8162308_3 | Unicycler tool version |
 

--- a/modules/generic/bakta.nf
+++ b/modules/generic/bakta.nf
@@ -7,10 +7,10 @@ process BAKTA {
     tag "${prefix}"
     label = [ 'process_medium', 'error_retry' ]
 
-    conda "bioconda::bakta=1.6.1"
+    conda "bioconda::bakta=1.7.0"
     container "${ workflow.containerEngine == 'singularity' ?
-        'https://depot.galaxyproject.org/singularity/bakta:1.6.1--pyhdfd78af_0' :
-        'quay.io/biocontainers/bakta:1.6.1--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/bakta:1.7.0--pyhdfd78af_1' :
+        'quay.io/biocontainers/bakta:1.7.0--pyhdfd78af_1' }"
 
     input:
     tuple val(prefix), val(entrypoint), file(sread1), file(sread2), file(sreads), file(lreads), val(lr_type), file(fast5), file(assembly), val(resfinder_species)

--- a/modules/generic/bakta.nf
+++ b/modules/generic/bakta.nf
@@ -38,6 +38,9 @@ process BAKTA {
     # Save bakta version
     bakta --version &> bakta_version.txt ;
 
+    # clean headers char limit
+    awk '{ if (\$0 ~ />/) print substr(\$0,1,21) ; else print \$0 }' $assembly > cleaned_header.fasta
+
     # Run bakta
     bakta \\
         --output annotation \\
@@ -46,7 +49,7 @@ process BAKTA {
         --prefix ${prefix} \\
         --strain '${prefix}' \\
         --db $bakta_db \\
-        $assembly
+        cleaned_header.fasta
     
     # fix fasta headers
     cut -f 1 -d ' ' annotation/${prefix}.fna > tmp.fa

--- a/modules/generic/prokka.nf
+++ b/modules/generic/prokka.nf
@@ -1,8 +1,8 @@
 process PROKKA {
     publishDir "${params.output}/${prefix}", mode: 'copy', saveAs: { filename ->
-      if (filename.indexOf("_version.txt") > 0) "tools_versioning/$filename"
-      else if (filename == "annotation") "$filename"
-      else null
+        if (filename.indexOf("_version.txt") > 0) "tools_versioning/$filename"
+        else if (filename == "annotation") "$filename"
+        else null
     }
     tag "${prefix}"
     label = [ 'process_medium' ]
@@ -31,11 +31,13 @@ process PROKKA {
     path('prokka_version.txt'), emit: version
 
     script:
-    kingdom = (params.prokka_kingdom)      ? "--kingdom ${params.prokka_kingdom}"        : ''
-    gcode   = (params.prokka_genetic_code) ? "--gcode ${params.prokka_genetic_code}"     : ''
-    rnammer = (params.prokka_use_rnammer)  ? "--rnammer"                                 : ''
-    models  = (params.prokka_use_pgap)     ? "PGAP_NCBI.hmm" : "TIGRFAMs_15.0.hmm"
+    kingdom = (params.prokka_kingdom)      ? "--kingdom ${params.prokka_kingdom}"    : ''
+    gcode   = (params.prokka_genetic_code) ? "--gcode ${params.prokka_genetic_code}" : ''
+    rnammer = (params.prokka_use_rnammer)  ? "--rnammer"                             : ''
+    models  = (params.prokka_use_pgap)     ? "PGAP_NCBI.hmm"                         : "TIGRFAMs_15.0.hmm"
     """
+    #!/usr/bin/env bash
+    
     # save prokka version
     prokka -v &> prokka_version.txt ;
 
@@ -50,6 +52,9 @@ process PROKKA {
     # hmmpress
     ( cd  prokka_db/hmm/ ; for i in *.hmm ; do hmmpress -f \$i ; done )
 
+    # clean headers char limit
+    awk '{ if (\$0 ~ />/) print substr(\$0,1,21) ; else print \$0 }' $assembly > cleaned_header.fasta
+
     # run prokka
     prokka \\
         --dbdir prokka_db \\
@@ -61,7 +66,7 @@ process PROKKA {
         --genus '' \\
         --species '' \\
         --strain \"${prefix}\" \\
-        $assembly
+        cleaned_header.fasta
     
     # remove tmp dir to gain space
     rm -r prokka_db

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -336,7 +336,7 @@
         "bakta_version": {
           "type": "string",
           "description": "Select quay.io image tag for tool",
-          "default": "1.6.1--pyhdfd78af_0"
+          "default": "1.7.0--pyhdfd78af_1"
         }
       }
     },


### PR DESCRIPTION
Add a small `awk` statement to clean big fasta headers only allowing 20 characters. Added to both `prokka` and `bakta`.
Should fix #85 