### PR TITLE
Fix issues #116

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -2,7 +2,7 @@
     "description": "<p>The pipeline</p>\n\n<p>bacannot, is a customisable, easy to use, pipeline that uses state-of-the-art software for comprehensively annotating prokaryotic genomes having only Docker and Nextflow as dependencies. It is able to annotate and detect virulence and resistance genes, plasmids, secondary metabolites, genomic islands, prophages, ICEs, KO, and more, while providing nice an beautiful interactive documents for results exploration.</p>", 
     "license": "other-open", 
     "title": "fmalmeida/bacannot: A generic but comprehensive bacterial annotation pipeline", 
-    "version": "v3.3", 
+    "version": "v3.3.2", 
     "upload_type": "software",
     "creators": [
         {

--- a/markdown/CHANGELOG.md
+++ b/markdown/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The tracking for changes started in v2.1
 
+## v3.3.2 [TBD]
+
+* [[#116](https://github.com/fmalmeida/bacannot/issues/116)] -- Small update to avoid having `integron_finder` gbks with start position as 0, since it breaks conversion to gff.
+
 ## v3.3.1 [29-October-2023]
 
 * [[#111](https://github.com/fmalmeida/bacannot/issues/111)] -- Updated `falmeida-py` package version to fix problem with missing key for Summary.

--- a/markdown/CHANGELOG.md
+++ b/markdown/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The tracking for changes started in v2.1
 
-## v3.3.2 [TBD]
+## v3.3.2 [09-February-2024]
 
 * [[#116](https://github.com/fmalmeida/bacannot/issues/116)] -- Small update to avoid having `integron_finder` gbks with start position as 0, since it breaks conversion to gff.
 

--- a/modules/MGEs/integron_finder_2gff.nf
+++ b/modules/MGEs/integron_finder_2gff.nf
@@ -13,7 +13,7 @@ process INTEGRON_FINDER_2GFF {
     def args = task.ext.args ?: ''
     """    
     # fix 0-based sequences
-    sed 's/0\\.\\./1\\.\\./g' $gbk > fixed.gbk
+    sed -e 's/ 0\\.\\./ 1\\.\\./g' -e 's/complement(0\\.\\./complement(1\\.\\./g' $gbk > fixed.gbk
     
     # convert to gff if available
     conda run -n perl bp_genbank2gff3 fixed.gbk -o - | \\

--- a/modules/MGEs/integron_finder_2gff.nf
+++ b/modules/MGEs/integron_finder_2gff.nf
@@ -16,9 +16,9 @@ process INTEGRON_FINDER_2GFF {
     sed 's/0\\.\\./1\\.\\./g' $gbk > fixed.gbk
     
     # convert to gff if available
-    conda run -n perl bp_genbank2gff3 fixed.gbk -o - | \
-        grep 'integron_id' | \
-        sed 's|ID=.*integron_id=|ID=|g' | \
+    conda run -n perl bp_genbank2gff3 fixed.gbk -o - | \\
+        grep 'integron_id' | \\
+        sed 's|ID=.*integron_id=|ID=|g' | \\
         sed 's/GenBank/Integron_Finder/g' >> ${prefix}_integrons.gff
     """
 }

--- a/modules/MGEs/integron_finder_2gff.nf
+++ b/modules/MGEs/integron_finder_2gff.nf
@@ -12,13 +12,13 @@ process INTEGRON_FINDER_2GFF {
     script:
     def args = task.ext.args ?: ''
     """    
+    # fix 0-based sequences
+    sed 's/0\\.\\./1\\.\\./g' $gbk > fixed.gbk
+    
     # convert to gff if available
-    touch ${prefix}_integrons.gff ;
-    for gbk in \$(ls *.gbk) ; do
-        conda run -n perl bp_genbank2gff3 \$gbk -o - | \
-            grep 'integron_id' | \
-            sed 's|ID=.*integron_id=|ID=|g' | \
-            sed 's/GenBank/Integron_Finder/g' >> ${prefix}_integrons.gff
-    done
+    conda run -n perl bp_genbank2gff3 fixed.gbk -o - | \
+        grep 'integron_id' | \
+        sed 's|ID=.*integron_id=|ID=|g' | \
+        sed 's/GenBank/Integron_Finder/g' >> ${prefix}_integrons.gff
     """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -108,7 +108,7 @@ manifest {
     homePage        = "https://github.com/fmalmeida/bacannot"
     mainScript      = "main.nf"
     nextflowVersion = "!>=22.10.1"
-    version         = '3.3'
+    version         = '3.3.2'
 }
 
 // Function to ensure that resource requirements don't go beyond


### PR DESCRIPTION
This PR is a quick patch release, thus pointed directly to master, to solve issue #116 where `integron_finder` would sometimes generate genbank files where items start in position 0.

However, position 0 is not allowed by the perl gbk2gff converter and thus, a small `sed` operation was added to modify these values to 1, when happening, before the conversion.

Code was tested by reporter user and thus, it can be merged when all small checkings are done.