### PR TITLE
118 add skip integron finder param

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -2,7 +2,7 @@
     "description": "<p>The pipeline</p>\n\n<p>bacannot, is a customisable, easy to use, pipeline that uses state-of-the-art software for comprehensively annotating prokaryotic genomes having only Docker and Nextflow as dependencies. It is able to annotate and detect virulence and resistance genes, plasmids, secondary metabolites, genomic islands, prophages, ICEs, KO, and more, while providing nice an beautiful interactive documents for results exploration.</p>", 
     "license": "other-open", 
     "title": "fmalmeida/bacannot: A generic but comprehensive bacterial annotation pipeline", 
-    "version": "v3.3.2", 
+    "version": "v3.3.3", 
     "upload_type": "software",
     "creators": [
         {

--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -122,6 +122,12 @@ params {
 // (NOT RUN?) antiSMASH (secondary metabolite) annotation
   skip_antismash = false
 
+// (NOT RUN?) integron finder tool
+  skip_integron_finder = false
+
+// (NOT RUN?) CIRCOS tool
+  skip_icircos = false
+
           /*
            * Custom databases can be used to annotate additional genes in the genome.
            * It runs a BLAST alignment against the genome, therefore, the custom database

--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -126,7 +126,7 @@ params {
   skip_integron_finder = false
 
 // (NOT RUN?) CIRCOS tool
-  skip_icircos = false
+  skip_circos = false
 
           /*
            * Custom databases can be used to annotate additional genes in the genome.

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -96,6 +96,8 @@ The use of this parameter sets a default value for input samples. If a sample ha
 | `--skip_prophage_search` | :material-close: | false | Tells whether not to run prophage annotation modules |
 | `--skip_kofamscan` | :material-close: | false | Tells whether not to run KEGG orthology (KO) annotation with KofamScan |
 | `--skip_antismash` | :material-close: | false | Tells whether or not to run antiSMASH (secondary metabolite) annotation. AntiSMASH is executed using only its core annotation modules in order to keep it fast. |
+| `--skip_circos` | :material-close: | false | Tells whether or not to run the final `CIRCOS` module. When the input genome has many contigs, its results are not meaningful. |
+| `--skip_integron_finder` | :material-close: | false | Tells whether or not to run the integron finder tool. |
 
 ## Custom databases
 

--- a/markdown/CHANGELOG.md
+++ b/markdown/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The tracking for changes started in v2.1
 
+## v3.3.3 [TBD]
+
+* [[#118](https://github.com/fmalmeida/bacannot/issues/116)]
+    * Add a parameter to allow user to skip `INTEGRON_FINDER` execution.
+    * Add a parameter to allow user to skip `CIRCOS` execution.
+
 ## v3.3.2 [09-February-2024]
 
 * [[#116](https://github.com/fmalmeida/bacannot/issues/116)] -- Small update to avoid having `integron_finder` gbks with start position as 0, since it breaks conversion to gff.

--- a/nextflow.config
+++ b/nextflow.config
@@ -108,7 +108,7 @@ manifest {
     homePage        = "https://github.com/fmalmeida/bacannot"
     mainScript      = "main.nf"
     nextflowVersion = "!>=22.10.1"
-    version         = '3.3.2'
+    version         = '3.3.3'
 }
 
 // Function to ensure that resource requirements don't go beyond

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -132,6 +132,12 @@
           "help_text": "If true, the process will be skipped!",
           "hidden": true
         },
+        "skip_circos": {
+          "type": "boolean",
+          "description": "Skip (do not run) circos?",
+          "help_text": "If true, the process will be skipped!",
+          "hidden": true
+        },
         "skip_plasmid_search": {
           "type": "boolean",
           "description": "Skip (do not run) plasmidfinder?",
@@ -153,6 +159,12 @@
         "skip_iceberg_search": {
           "type": "boolean",
           "description": "Skip (do not run) ICEs annotation?",
+          "help_text": "If true, the process will be skipped!",
+          "hidden": true
+        },
+        "skip_integron_finder": {
+          "type": "boolean",
+          "description": "Skip (do not run) integron finder?",
           "help_text": "If true, the process will be skipped!",
           "hidden": true
         },

--- a/workflows/bacannot.nf
+++ b/workflows/bacannot.nf
@@ -140,8 +140,13 @@ workflow BACANNOT {
       ISLANDPATH( annotation_out_ch.gbk )
 
       // Integron_finder software
-      INTEGRON_FINDER( annotation_out_ch.genome )
-      INTEGRON_FINDER_2GFF( INTEGRON_FINDER.out.gbk )
+      if (!params.skip_integron_finder) {
+        INTEGRON_FINDER( annotation_out_ch.genome )
+        INTEGRON_FINDER_2GFF( INTEGRON_FINDER.out.gbk )
+        ch_integron_finder_gff = INTEGRON_FINDER_2GFF.out.gff
+      } else {
+        ch_integron_finder_gff = Channel.empty()
+      }
 
       // Virulence search
       if (params.skip_virulence_search == false) {     
@@ -300,7 +305,7 @@ workflow BACANNOT {
           .join(phast_output_ch,                 remainder: true)
           .join(DIGIS.out.gff,                   remainder: true)
           .join(ch_custom_annotations,           remainder: true)
-          .join(INTEGRON_FINDER_2GFF.out.gff,    remainder: true)
+          .join(ch_integron_finder_gff,          remainder: true)
       )
 
       /*
@@ -340,7 +345,7 @@ workflow BACANNOT {
           .join( MERGE_ANNOTATIONS.out.digis_gff                 )
           .join( antismash_output_ch,            remainder: true )
           .join( MERGE_ANNOTATIONS.out.customdb_gff.groupTuple(), remainder: true )
-          .join( INTEGRON_FINDER_2GFF.out.gff,   remainder: true )
+          .join( ch_integron_finder_gff,         remainder: true )
       )
 
       // Render reports
@@ -376,7 +381,7 @@ workflow BACANNOT {
           .join( DRAW_GIS.out.example,            remainder: true )
           .join( phast_output_ch,                 remainder: true )
           .join( MERGE_ANNOTATIONS.out.digis_gff                  )
-          .join( INTEGRON_FINDER_2GFF.out.gff,    remainder: true )
+          .join( ch_integron_finder_gff,          remainder: true )
       )
 
       //
@@ -405,7 +410,7 @@ workflow BACANNOT {
         .join( DIGIS.out.all               , remainder: true )
         .join( antismash_all_ch            , remainder: true )
         .join( MERGE_ANNOTATIONS.out.all   , remainder: true )
-        .join( INTEGRON_FINDER_2GFF.out.gff, remainder: true )
+        .join( ch_integron_finder_gff      , remainder: true )
         .join( mobsuite_output_ch          , remainder: true )
       )
       MERGE_SUMMARIES(
@@ -413,19 +418,19 @@ workflow BACANNOT {
       )
 
       // Render circos plots
-      circos_input_ch =
-        annotation_out_ch.genome
-        .join( annotation_out_ch.gff    , remainder: true )
-        .join( MERGE_ANNOTATIONS.out.gff, remainder: true )
-        .join( PHISPY.out.gff           , remainder: true )
-        .map{
-          it ->
-            sample = it[0]
-            it.remove(0)
-            [ sample, it ]
-        }
-      CIRCOS(
-        circos_input_ch
-      )
+      if (!params.skip_circos) {
+        circos_input_ch =
+          annotation_out_ch.genome
+          .join( annotation_out_ch.gff    , remainder: true )
+          .join( MERGE_ANNOTATIONS.out.gff, remainder: true )
+          .join( PHISPY.out.gff           , remainder: true )
+          .map{
+            it ->
+              sample = it[0]
+              it.remove(0)
+              [ sample, it ]
+          }
+        CIRCOS( circos_input_ch )
+      }
 
 }


### PR DESCRIPTION
Adding parameters to skip integron finder and circos tools when required. Sometimes, the input genomes may not be compatible to such tools as saw in #118.