### PR TITLE
127 pipeline fails when genome not found on ncbi

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -38,4 +38,14 @@ process {
         maxRetries    = 2
     }
 
+    // problematic module
+    withName: GET_NCBI_GENOME {
+        errorStrategy = { task.attempt > 4 ? 'retry' : 'ignore' }
+        maxRetries    = 2
+        maxErrors     = '-1'
+        cpus          = 2
+        memory        = 4.GB
+        time          = 2.h
+    }
+
 }

--- a/workflows/bacannot.nf
+++ b/workflows/bacannot.nf
@@ -287,6 +287,10 @@ workflow BACANNOT {
           params.sourmash_scale,
           params.sourmash_kmer
         )
+
+        ch_sourmash_plot = SOURMASH_ALL.out.plot.first()
+      } else {
+        ch_sourmash_plot = []
       }
 
       //
@@ -419,7 +423,7 @@ workflow BACANNOT {
           .join( phast_output_ch,                 remainder: true )
           .join( MERGE_ANNOTATIONS.out.digis_gff                  )
           .join( ch_integron_finder_gff,          remainder: true ),
-        SOURMASH_ALL.out.plot.first() // make value channel
+        ch_sourmash_plot
       )
 
       //


### PR DESCRIPTION
PR to solve #127 
Includes small change to allow the module `GET_NCBI_GENOME` to fail, since sometimes an assembly is not found and a small channel fix to make `REPORTS` module be executed when skipping sourmash.